### PR TITLE
Add filmbooster.com support and small improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "husky": "^8.0.3",
     "imports-loader": "^4.0.1",
     "mini-css-extract-plugin": "^2.7.2",
-    "node-sass": "^8.0.0",
+    "node-sass": "^9.0.0",
     "prettier": "^2.8.3",
     "pretty-quick": "^3.1.3",
     "rimraf": "^4.1.2",

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -23,6 +23,12 @@
   "elsewhere": {
     "message": "Hodně budeš někde..."
   },
+  "elsewhere2": {
+    "message": "nebo tady"
+  },
+  "openOnSite": {
+    "message": "Otevřít na"
+  },
   "more": {
     "message": "Více"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -30,6 +30,14 @@
     "message": "Try it somewhere else...",
     "description": "Try it somewhere else link."
   },
+  "elsewhere2": {
+    "message": "or search here",
+    "description": "Search link here"
+  },
+  "openOnSite": {
+    "message": "Open on",
+    "description": "Open on different site"
+  },
   "more": {
     "message": "More",
     "description": "Universal 'more' string"

--- a/src/app.scss
+++ b/src/app.scss
@@ -83,6 +83,10 @@ $padding-x: 10px;
     text-align: center;
   }
 
+  .text-right {
+    text-align: right;
+  }
+
   .elsewhere {
     margin-top: 5px;
   }
@@ -93,6 +97,15 @@ $padding-x: 10px;
 
   .text-lowercase {
     text-transform: lowercase;
+  }
+
+  .link-to-booster {
+    padding-top: 8px;
+  }
+
+  .link-alternatives {
+    padding-top: 5px;
+    padding-bottom: 5px;
   }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import Alternatives from './services/alternatives';
 import Cleaner from './services/cleaner';
 import Renderer from './services/renderer';
 import Store from './services/store';
-import { getCSFDSiteDomain, getFilmID, isDev } from './services/utils';
+import { getAlternativeDomain, getCSFDSiteDomain, getFilmID, isDev } from './services/utils';
 
 /**
  * @class CsfdMagnets
@@ -91,7 +91,9 @@ class CsfdMagnets {
     this.wrapper = this.renderer.prepareBox(
       this.placingNode[0],
       this.movieTitle,
-      searchUrl(this.movieTitle)
+      searchUrl(this.movieTitle),
+      window.location.pathname,
+      getAlternativeDomain(this.store.CSFDSiteDomain)
     );
     console.log(`CSFD MAGNETS ${isDev ? 'β' : ''}: Searching for '${this.movieTitle}'...`);
     this.getItems(this.movieTitle);

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import Alternatives from './services/alternatives';
 import Cleaner from './services/cleaner';
 import Renderer from './services/renderer';
 import Store from './services/store';
-import { getFilmID, isDev } from './services/utils';
+import { getCSFDSiteDomain, getFilmID, isDev } from './services/utils';
 
 /**
  * @class CsfdMagnets
@@ -34,7 +34,9 @@ class CsfdMagnets {
     private store: Store
   ) {
     const url = window.location.href.split('/');
-    if (url[2].includes('csfd.') && url[3] === 'film') {
+    this.store.CSFDSiteDomain = getCSFDSiteDomain(url[2]);
+
+    if (this.store.CSFDSiteDomain && url[3] === 'film') {
       this.placingNode = document.querySelectorAll('.box-rating-container');
 
       // Save filmId into store
@@ -58,9 +60,25 @@ class CsfdMagnets {
 
       this.altTitles = this.alternative.getAltTitles();
 
-      const filmTitle = this.altTitles[0] || document.title;
+      const filmTitle = this.getTitle();
 
       this.searchMovie(filmTitle);
+    }
+  }
+
+  /**
+   * Search movie (trigger)
+   */
+  private getTitle(): string {
+    switch (this.store.filmType) {
+      case 'episode':
+      case 'epizoda':
+        return document.title;
+
+      default:
+        return this.store.CSFDSiteDomain === 'csfd.*'
+          ? this.altTitles[0] || document.title
+          : document.title;
     }
   }
 

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -25,7 +25,11 @@ export type CSFDFilmTypes =
   | 'divadelní záznam'
   | 'koncert'
   | 'série'
+  | 'series'
   | 'studentský film'
   | 'amatérský film'
   | 'hudební videoklip'
-  | 'epizoda';
+  | 'epizoda'
+  | 'episode';
+
+export type CSFDSiteDomain = 'csfd.*' | 'filmbooster.*';

--- a/src/manifest-common.json
+++ b/src/manifest-common.json
@@ -18,7 +18,7 @@
   "content_scripts": [
     {
       "run_at": "document_end",
-      "matches": ["https://*.csfd.cz/*", "https://*.csfd.sk/*"],
+      "matches": ["https://*.csfd.cz/*", "https://*.csfd.sk/*", "https://*.filmbooster.com/*"],
       "css": ["app.css"],
       "js": ["app.bundle.js"]
     }

--- a/src/services/cleaner.ts
+++ b/src/services/cleaner.ts
@@ -48,7 +48,12 @@ export default class Cleaner {
    */
   private addYear(filmTitle: string): string {
     const filmType = this.store.filmType;
-    if (filmType !== 'TV seriál' && filmType !== 'epizoda' && filmType !== 'série') {
+    if (
+      filmType !== 'TV seriál' &&
+      filmType !== 'epizoda' &&
+      filmType !== 'episode' &&
+      filmType !== 'série'
+    ) {
       return filmTitle + ' ' + (this.store.year || '');
     } else {
       return filmTitle;
@@ -81,7 +86,7 @@ export default class Cleaner {
    */
   private prepareEpisode(title: string): string {
     const filmType = this.store.filmType;
-    if (filmType === 'epizoda') {
+    if (filmType === 'epizoda' || filmType === 'episode') {
       const titleSplit = title.split('-');
       const episodeArray = title.match(this.episodePattern);
 

--- a/src/services/renderer.ts
+++ b/src/services/renderer.ts
@@ -25,7 +25,9 @@ export default class Renderer {
   public prepareBox(
     placingNode: HTMLElement,
     movieTitle: string,
-    searchUrl: string
+    searchUrl: string,
+    urlPath: string,
+    alternativeSiteDomain: string
   ): HTMLDivElement {
     const wrapper = document.createElement('div');
     wrapper.classList.add('tpb-wrapper');
@@ -95,15 +97,21 @@ export default class Renderer {
           <ul></ul>
           <span class="not-found">
             ¯/\_(ツ)_/¯                      
-            <div class="box-content-more text-center">
-              <a href="https://ulozto.cz/hledej?q=${movieTitle}" target="_blank">${_(
-      'elsewhere'
-    )}</a>
-            </div>    
-          </span>                 
-          <div class="box-content-more more-found text-lowercase text-center">
+          </span>
+          <div class="box-content-more more-found text-lowercase">
             <a href="${searchUrl}">${_('more')}</a>
           </div>
+
+          <div class="link-alternatives text-center">
+          <a href="https://ulozto.cz/hledej?q=${movieTitle}" target="_blank">${_(
+      'elsewhere'
+    )}</a> <a href="https://webshare.cz/#/search?what=${movieTitle}">${_('elsewhere2')}</a>
+      
+        </div>    
+        
+          <div class="box-content-more text-right link-to-booster"><a href="https://${alternativeSiteDomain}/${urlPath}">${_(
+      'openOnSite'
+    )} ${alternativeSiteDomain}</a></div>     
         </div>
       </div>`;
 

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -8,10 +8,11 @@
  * @see https://github.com/bartholomej/csfd-magnets
  */
 
-import { CSFDFilmTypes } from '@interfaces/interfaces';
+import { CSFDFilmTypes, CSFDSiteDomain } from '@interfaces/interfaces';
 
 export default class Store {
   private id: number;
+  private _CSFDSiteDomain: CSFDSiteDomain;
   private _year: number;
   private _filmType: CSFDFilmTypes;
 
@@ -37,5 +38,13 @@ export default class Store {
 
   public set filmType(filmType: CSFDFilmTypes) {
     this._filmType = filmType;
+  }
+
+  public set CSFDSiteDomain(CSFDSiteDomain: CSFDSiteDomain) {
+    this._CSFDSiteDomain = CSFDSiteDomain;
+  }
+
+  public get CSFDSiteDomain(): CSFDSiteDomain {
+    return this._CSFDSiteDomain;
   }
 }

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -25,6 +25,17 @@ export const getCSFDSiteDomain = (url: string): CSFDSiteDomain | null => {
   return null;
 };
 
+export const getAlternativeDomain = (domain: CSFDSiteDomain): string => {
+  switch (domain) {
+    case 'csfd.*':
+      return 'filmbooster.com';
+    case 'filmbooster.*':
+      return 'csfd.cz';
+    default:
+      return 'filmbooster.com';
+  }
+};
+
 export const altTitlesPattern = [
   'USA',
   'angličtina',

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -8,11 +8,21 @@
  * @see https://github.com/bartholomej/csfd-magnets
  */
 
+import { CSFDSiteDomain } from '@interfaces/interfaces';
+
 export const isProd = process.env.NODE_ENV === 'production';
 export const isDev = process.env.NODE_ENV === 'development';
 
 export const getFilmID = (url: string): number => {
   return +url.split('-')[0];
+};
+
+export const getCSFDSiteDomain = (url: string): CSFDSiteDomain | null => {
+  if (url.includes('csfd.')) return 'csfd.*';
+
+  if (url.includes('filmbooster.')) return 'filmbooster.*';
+
+  return null;
 };
 
 export const altTitlesPattern = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,10 +2133,10 @@ node-releases@^2.0.1:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
-node-sass@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-8.0.0.tgz#c80d52148db0ce88610bcf1e1d112027393c13e1"
-  integrity sha512-jPzqCF2/e6JXw6r3VxfIqYc8tKQdkj5Z/BDATYyG6FL6b/LuYBNFGFVhus0mthcWifHm/JzBpKAd+3eXsWeK/A==
+node-sass@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-9.0.0.tgz#c21cd17bd9379c2d09362b3baf2cbf089bce08ed"
+  integrity sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^4.1.2"


### PR DESCRIPTION
- get series title for episode search instead of episode name
- adds support for new English variant of CSFD filmbooster.com (works better with en series and movies titles)
- link to movie detail on alternative site eg. filmbooster.com
- show alternative links for search by default (previously were shown only when nothing was found)

![Screenshot 2023-07-31 151358](https://github.com/bartholomej/csfd-magnets/assets/8448523/3bc0b759-f0cc-4fdc-9a6e-59586430ec23)

![Screenshot 2023-07-31 151319](https://github.com/bartholomej/csfd-magnets/assets/8448523/77d09465-dd14-4270-bd39-b5b44368e2b9)
